### PR TITLE
Update Ford Fiesta generations: Add references and standardize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,6 @@
 
 This repository contains signal set configurations for the Ford Fiesta, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Ford Fiesta.
 
-## Generations
-
-- **First Generation (1976-1983)**: Launched as Ford's first globally successful front-wheel-drive car, codenamed "Project Bobcat." It featured a range of engines from 957cc to 1.6L, including the sporty XR2 variant. The car was designed to be economical and practical, with a transverse engine layout that maximized interior space.
-
-- **Second Generation (1983-1989)**: Known internally as project "BE-13," this generation brought improved aerodynamics and updated styling while maintaining the successful formula of the original. Notable introductions included the first diesel engine option and the high-performance XR2 with a 1.6L engine producing 96 hp.
-
-- **Third Generation (1989-1997)**: Designated "BE-8," this generation featured more rounded styling and improved safety features. The range included the first RS Turbo and RS1800 models, along with the introduction of five-door variants. Engine options ranged from 1.0L to 1.8L, with both gasoline and diesel options.
-
-- **Fourth Generation (1995-2002)**: This generation, known as the "BE-91," brought major styling updates and improved build quality. It introduced new Zetec engines and featured more sophisticated suspension. The sporty lineup expanded with the Zetec-S and RS models, the latter featuring a 1.6L engine producing up to 103 hp.
-
-- **Fifth Generation (2002-2008)**: Based on Ford's global B platform, this generation marked a significant improvement in refinement and driving dynamics. It introduced the first Fiesta ST model with a 2.0L engine producing 148 hp, and offered a range of improved Duratec gasoline and Duratorq diesel engines.
-
-- **Sixth Generation (2008-2019)**: Built on a modernized B-platform, this generation brought the "Kinetic Design" styling language. It featured significantly improved interior quality, new EcoBoost engines, and advanced technology features. The ST variant became a benchmark for hot hatches with its 1.6L EcoBoost engine producing 180 hp.
-
-- **Seventh Generation (2017-2023)**: The final generation of the Fiesta featured enhanced connectivity, driver assistance systems, and refined powertrains. It offered the most powerful ST variant yet, with a 1.5L three-cylinder EcoBoost engine producing 197 hp. Production ended in 2023 as Ford shifted focus to SUVs and electric vehicles in many markets.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Ford_Fiesta"
+
 generations:
   - name: "First Generation (Project Bobcat)"
     start_year: 1976


### PR DESCRIPTION
- Added references section to generations.yaml
- Updated README.md to standard template format
- Removed custom generations section from README
- Retained comprehensive generation data for 7 generations (1976-2023)
- Note: Wikipedia article not accessible via local server

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
